### PR TITLE
Fix the issue #137 at https://github.com/bg111/asterisk-chan-dongle/issues/137

### DIFF
--- a/at_command.c
+++ b/at_command.c
@@ -35,6 +35,8 @@ static const char cmd_chld2[]    = "AT+CHLD=2\r";
 static const char cmd_clcc[]     = "AT+CLCC\r";
 static const char cmd_ddsetex2[] = "AT^DDSETEX=2\r";
 
+static int cpms_sm = 0;
+
 /*!
  * \brief Format and fill generic command
  * \param cmd -- the command structure
@@ -133,7 +135,7 @@ EXPORT_DEF int at_enque_initialization(struct cpvt* cpvt, at_cmd_t from_command)
 	static const char cmd19[] = "AT+CSSN=1,1\r";
 	static const char cmd21[] = "AT+CSCS=\"UCS2\"\r";
 
-	static const char cmd22[] = "AT+CPMS=\"ME\",\"ME\",\"ME\"\r";
+	static       char cmd22[] = "AT+CPMS=\"ME\",\"ME\",\"ME\"\r";
 	static const char cmd23[] = "AT+CNMI=2,1,0,0,0\r";
 	static const char cmd24[] = "AT+CSQ\r";
 
@@ -193,6 +195,8 @@ EXPORT_DEF int at_enque_initialization(struct cpvt* cpvt, at_cmd_t from_command)
 			continue;
 		if(st_cmds[in].cmd == CMD_AT_U2DIAG && CONF_SHARED(pvt, u2diag) == -1)
 			continue;
+		if(st_cmds[in].cmd == CMD_AT_CPMS && cpms_sm)
+			strcpy(cmd22, "AT+CPMS=\"SM\",\"SM\",\"SM\"\r");
 
 		memcpy(&cmds[out], &st_cmds[in], sizeof(st_cmds[in]));
 
@@ -224,6 +228,20 @@ failure:
 	if(ptmp2)
 		ast_free(ptmp2);
 	return err;
+}
+
+/* Set "AT+CPMS=\"SM\",\"SM\",\"SM\"\r"
+	0: Already set
+	1: Successfully set
+*/
+EXPORT_DEF int set_cpms_sm ()
+{
+	if (!cpms_sm)
+	{
+		cpms_sm = 1;
+		return 1;
+	}
+	return 0;
 }
 
 /*!

--- a/at_command.h
+++ b/at_command.h
@@ -148,6 +148,7 @@ struct cpvt;
 
 EXPORT_DECL const char* at_cmd2str (at_cmd_t cmd);
 EXPORT_DECL int at_enque_initialization(struct cpvt * cpvt, at_cmd_t from_command);
+EXPORT_DECL int set_cpms_sm ();
 EXPORT_DECL int at_enque_ping (struct cpvt * cpvt);
 EXPORT_DECL int at_enque_cops (struct cpvt * cpvt);
 EXPORT_DECL int at_enque_sms (struct cpvt * cpvt, const char * number, const char * msg, unsigned validity_min, int report_req, void ** id);

--- a/at_response.c
+++ b/at_response.c
@@ -410,8 +410,21 @@ static int at_response_error (struct pvt* pvt, at_res_t res)
 				ast_log (LOG_ERROR, "[%s] Error Supplementary Service Notification activation failed\n", PVT_ID(pvt));
 				goto e_return;
 
-			case CMD_AT_CMGF:
 			case CMD_AT_CPMS:
+				/* Switch to "AT+CPMS=\"SM\",\"SM\",\"SM\"\r" */
+				if (set_cpms_sm ())
+				{
+					ast_debug (1, "Switch to 'AT+CPMS=\"SM\",\"SM\",\"SM\"'\n", PVT_ID(pvt));
+					/* restart initialization from cmd CMD_AT_CPMS */
+					if (at_enque_initialization(task->cpvt, CMD_AT_CPMS))
+					{
+						ast_log (LOG_ERROR, "[%s] Error querying SMS storage selection\n", PVT_ID(pvt));
+						goto e_return;
+					}
+					break;
+				}
+
+			case CMD_AT_CMGF:
 			case CMD_AT_CNMI:
 				ast_debug (1, "[%s] Command '%s' failed\n", PVT_ID(pvt), at_cmd2str (ecmd->cmd));
 				ast_debug (1, "[%s] No SMS support\n", PVT_ID(pvt));


### PR DESCRIPTION
At initialization, try 'AT+CPMS="ME","ME","ME"', first.
If fails, switch to 'AT+CPMS="SM","SM","SM"'.

Signed-off-by: sstream sstream00@yahoo.co.jp
