### PR TITLE
Resolves bg111/asterisk-chan-dongle#183

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,6 +1,6 @@
 Known bugs
 
-	1) SMS sending charset problem
+1) SMS sending charset problem
 		solved by PDU
 2) HW: Terminate (from both side) active call break voice on all held
 
@@ -22,12 +22,12 @@ kill device. Device not responding on commands but still sending ^BOOT: and ^RSS
 
 10) HW device reboot and chan_dongle crash on receive long SMS in TEXT UCS2 mode (>150 symbols)
 
-	11) DTMF not send ?
+11) DTMF not send ?
 
-	12) zombi calls
+12) zombi calls
 
 13) HW: device still in sms prompt infinite (only 0x1B can help) if entered more 133 symbols in TEXT UCS-2 mode
 
 14) Sometimes device stops responding to commands
 
-	15) SIGSEGV on hangup
+15) SIGSEGV on hangup

--- a/at_command.c
+++ b/at_command.c
@@ -418,7 +418,7 @@ EXPORT_DEF int at_enque_ussd (struct cpvt * cpvt, const char * code, attribute_u
 	length = STRLEN(cmd);
 
 	if (pvt->cusd_use_7bit_encoding)
-		cusd_encoding = STR_ENCODING_7BIT_HEX;
+		cusd_encoding = STR_ENCODING_7BIT_HEX_PAD_0;
 	else if (pvt->use_ucs2_encoding)
 		cusd_encoding = STR_ENCODING_UCS2_HEX;
 	else

--- a/at_response.c
+++ b/at_response.c
@@ -1345,7 +1345,7 @@ static int at_response_cusd (struct pvt * pvt, char * str, size_t len)
 
 	// FIXME: strictly check USSD encoding and detect encoding
 	if ((dcs == 0 || dcs == 15) && !pvt->cusd_use_ucs2_decoding)
-		ussd_encoding = STR_ENCODING_7BIT_HEX;
+		ussd_encoding = STR_ENCODING_7BIT_HEX_PAD_0;
 	else
 		ussd_encoding = STR_ENCODING_UCS2_HEX;
 	res = str_recode (RECODE_DECODE, ussd_encoding, cusd, strlen (cusd), cusd_utf8_str, sizeof (cusd_utf8_str));

--- a/chan_dongle.h
+++ b/chan_dongle.h
@@ -129,7 +129,8 @@ typedef struct pvt
 	struct timeval		dtmf_end_time;			/*!< time of end of last DTMF digit */
 
 	int			timeout;			/*!< used to set the timeout for data */
-#define DATA_READ_TIMEOUT	10000				/* 10 seconds */
+#define DATA_READ_TIMEOUT	15000				/* 30 seconds, play nicer with E303S. Fixes
+                                                                https://github.com/bg111/asterisk-chan-dongle/issues/215 */
 
 	unsigned long		channel_instanse;		/*!< number of channels created on this device */
 	unsigned int		rings;				/*!< ring/ccwa  number distributed to at_response_clcc() */

--- a/char_conv.c
+++ b/char_conv.c
@@ -159,96 +159,182 @@ static ssize_t utf8_to_hexstr_ucs2 (const char* in, size_t in_length, char* out,
 	return res;
 }
 
-static ssize_t char_to_hexstr_7bit (const char* in, size_t in_length, char* out, size_t out_size)
+static ssize_t char_to_hexstr_7bit_padded(const char* in, size_t in_length, char* out,
+    size_t out_size, unsigned out_padding)
 {
-	size_t		i;
-	size_t		x = 0;
-	size_t		s;
-	unsigned char	c;
-	unsigned char	b;
-	char	buf[] = { 0x0, 0x0, 0x0 };
+	size_t i;
+	size_t x;
+	char buf[4];
+	unsigned value = 0;
 
-	x = (in_length - in_length / 8) * 2;
-	if (out_size - 1 < x)
-	{
+	/* compute number of bytes we need for the final string, rounded up */
+	x = ((out_padding + (7 * in_length) + 7) / 8);
+	/* compute number of hex characters we need for the final string */
+	x = (2 * x) + 1 /* terminating zero */;
+
+	/* check that the buffer is not too small */
+	if (x > out_size)
 		return -1;
+
+	for (x = i = 0; i != in_length; i++) {
+		value |= (in[i] & 0x7F) << out_padding;
+		out_padding += 7;
+		if (out_padding < 8)
+			continue;
+		/* output one byte in hex */
+		snprintf (buf, sizeof(buf), "%02X", value & 0xFF);
+		memcpy (out + x, buf, 2);
+		x = x + 2;
+		value >>= 8;
+		out_padding -= 8;
 	}
-
-	if(in_length > 0)
-	{
-		in_length--;
-		for (i = 0, x = 0, s = 0; i < in_length; i++)
-		{
-			if (s == 7)
-			{
-				s = 0;
-				continue;
-			}
-
-			c = in[i] >> s;
-			b = in[i + 1] << (7 - s);
-			c = c | b;
-			s++;
-
-			snprintf (buf, sizeof(buf), "%.2X", c);
-
-			memcpy (out + x, buf, 2);
-			x = x + 2;
-		}
-
-		c = in[i] >> s;
-		snprintf (buf, sizeof(buf), "%.2X", c);
+	if (out_padding != 0) {
+		snprintf (buf, sizeof(buf), "%02X", value & 0xFF);
 		memcpy (out + x, buf, 2);
 		x = x + 2;
 	}
+	/* zero terminate final string */
 	out[x] = '\0';
 
+	/* return total string length, excluding terminating zero */
 	return x;
 }
 
-static ssize_t hexstr_7bit_to_char (const char* in, size_t in_length, char* out, size_t out_size)
+static ssize_t char_to_hexstr_7bit_pad_0(const char* in, size_t in_length, char* out,
+    size_t out_size)
 {
-	size_t		i;
-	size_t		x;
-	size_t		s;
-	int		hexval;
-	unsigned char	c;
-	unsigned char	b;
-	char	buf[] = { 0x0, 0x0, 0x0 };
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 0);
+}
 
-	in_length = in_length / 2;
-	x = in_length + in_length / 7;
-	if (out_size - 1 < x)
-	{
-		return -1;
+static ssize_t char_to_hexstr_7bit_pad_1(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 1);
+}
+
+static ssize_t char_to_hexstr_7bit_pad_2(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 2);
+}
+
+static ssize_t char_to_hexstr_7bit_pad_3(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 3);
+}
+
+static ssize_t char_to_hexstr_7bit_pad_4(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 4);
+}
+
+static ssize_t char_to_hexstr_7bit_pad_5(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 5);
+}
+
+static ssize_t char_to_hexstr_7bit_pad_6(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return char_to_hexstr_7bit_padded(in, in_length, out, out_size, 6);
+}
+
+static ssize_t hexstr_7bit_to_char_padded(const char* in, size_t in_length, char* out,
+    size_t out_size, unsigned in_padding)
+{
+	size_t i;
+	size_t x;
+	char buf[4];
+	unsigned value = 0;
+	unsigned hexval;
+
+	/* compute number of bytes */
+	in_length /= 2;
+
+	/* check if string is empty */
+	if (in_length == 0) {
+		out[0] = '\0';
+		return (0);
 	}
 
-	for (i = 0, x = 0, s = 1, b = 0; i < in_length; i++)
-	{
+	/* compute number of characters */
+	x = (((in_length * 8) - in_padding) / 7) + 1 /* terminating zero */;
+
+	/* check if final string fits within buffer */
+	if (x > out_size)
+		return -1;
+
+	/* account for the bit padding */
+	in_padding = 7 - in_padding;
+
+	/* clear temporary buffer */
+	memset(buf, 0, sizeof(buf));
+
+	/* parse the hexstring */
+	for (x = i = 0; i != in_length; i++) {
 		memcpy (buf, in + i * 2, 2);
 		if (sscanf (buf, "%x", &hexval) != 1)
-		{
 			return -1;
-		}
+		value |= (hexval & 0xFF) << in_padding;
+		in_padding += 8;
 
-		c = ((unsigned char) hexval) << s;
-		c = (c >> 1) | b;
-		b = ((unsigned char) hexval) >> (8 - s);
-
-		out[x] = c;
-		x++; s++;
-
-		if (s == 8)
-		{
-			out[x] = b;
-			s = 1; b = 0;
-			x++;
+		while (in_padding >= (2 * 7)) {
+			in_padding -= 7;
+			value >>= 7;
+			out[x++] = value & 0x7F;
 		}
 	}
 
+	/* zero terminate final string */
 	out[x] = '\0';
 
+	/* return total string length, excluding terminating zero */
 	return x;
+}
+
+static ssize_t hexstr_7bit_to_char_pad_0(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 0);
+}
+
+static ssize_t hexstr_7bit_to_char_pad_1(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 1);
+}
+
+static ssize_t hexstr_7bit_to_char_pad_2(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 2);
+}
+
+static ssize_t hexstr_7bit_to_char_pad_3(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 3);
+}
+
+static ssize_t hexstr_7bit_to_char_pad_4(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 4);
+}
+
+static ssize_t hexstr_7bit_to_char_pad_5(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 5);
+}
+
+static ssize_t hexstr_7bit_to_char_pad_6(const char* in, size_t in_length, char* out,
+    size_t out_size)
+{
+	return  hexstr_7bit_to_char_padded(in, in_length, out, out_size, 6);
 }
 
 #/* */
@@ -267,13 +353,18 @@ ssize_t just_copy (const char* in, size_t in_length, char* out, size_t out_size)
 typedef ssize_t (*coder) (const char* in, size_t in_length, char* out, size_t out_size);
 
 /* array in order of values RECODE_*  */
-static const coder recoders[][2] =
+static const coder recoders[STR_ENCODING_UNKNOWN][2] =
 {
-/* in order of values STR_ENCODING_*  */
-	{ hexstr_7bit_to_char, char_to_hexstr_7bit },		/* STR_ENCODING_7BIT_HEX */
-	{ hexstr_to_8bitchars, chars8bit_to_hexstr },		/* STR_ENCODING_8BIT_HEX */
-	{ hexstr_ucs2_to_utf8, utf8_to_hexstr_ucs2 },		/* STR_ENCODING_UCS2_HEX */
-	{ just_copy, just_copy },				/* STR_ENCODING_7BIT */
+	[STR_ENCODING_7BIT_HEX_PAD_0] = { hexstr_7bit_to_char_pad_0, char_to_hexstr_7bit_pad_0 },
+	[STR_ENCODING_8BIT_HEX] = { hexstr_to_8bitchars, chars8bit_to_hexstr },
+	[STR_ENCODING_UCS2_HEX] = { hexstr_ucs2_to_utf8, utf8_to_hexstr_ucs2 },
+	[STR_ENCODING_7BIT] = { just_copy, just_copy },
+	[STR_ENCODING_7BIT_HEX_PAD_1] = { hexstr_7bit_to_char_pad_1, char_to_hexstr_7bit_pad_1 },
+	[STR_ENCODING_7BIT_HEX_PAD_2] = { hexstr_7bit_to_char_pad_2, char_to_hexstr_7bit_pad_2 },
+	[STR_ENCODING_7BIT_HEX_PAD_3] = { hexstr_7bit_to_char_pad_3, char_to_hexstr_7bit_pad_3 },
+	[STR_ENCODING_7BIT_HEX_PAD_4] = { hexstr_7bit_to_char_pad_4, char_to_hexstr_7bit_pad_4 },
+	[STR_ENCODING_7BIT_HEX_PAD_5] = { hexstr_7bit_to_char_pad_5, char_to_hexstr_7bit_pad_5 },
+	[STR_ENCODING_7BIT_HEX_PAD_6] = { hexstr_7bit_to_char_pad_6, char_to_hexstr_7bit_pad_6 },
 };
 
 #/* */
@@ -293,7 +384,7 @@ EXPORT_DEF str_encoding_t get_encoding(recode_direction_t hint, const char* in, 
 		for(; length; --length, ++in)
 			if(*in & 0x80)
 				return STR_ENCODING_UCS2_HEX;
-		return STR_ENCODING_7BIT_HEX;
+		return STR_ENCODING_7BIT_HEX_PAD_0;
 	}
 	else
 	{
@@ -304,7 +395,7 @@ EXPORT_DEF str_encoding_t get_encoding(recode_direction_t hint, const char* in, 
 				return STR_ENCODING_7BIT;
 			}
 		}
-		// TODO: STR_ENCODING_7BIT_HEX or STR_ENCODING_8BIT_HEX or STR_ENCODING_UCS2_HEX
+		// TODO: STR_ENCODING_7BIT_HEX_PAD_X or STR_ENCODING_8BIT_HEX or STR_ENCODING_UCS2_HEX
 	}
 
 	return STR_ENCODING_UNKNOWN;

--- a/char_conv.h
+++ b/char_conv.h
@@ -11,11 +11,17 @@
 /* for simplefy first 3 values same as in PDU DCS bits 3..2 */
 /* NOTE: order is magic see definition of recoders in char_conv.c */
 typedef enum {
-	STR_ENCODING_7BIT_HEX		= 0,	/* 7bit encoding */
+	STR_ENCODING_7BIT_HEX_PAD_0 = 0,	/* 7bit encoding, 0 bits of padding */
 	STR_ENCODING_8BIT_HEX,			/* 8bit encoding */
 	STR_ENCODING_UCS2_HEX,			/* UCS-2 in hex like PDU */
 /* TODO: check its really 7bit input from device */
 	STR_ENCODING_7BIT,			/* 7bit ASCII  no need recode to utf-8 */
+	STR_ENCODING_7BIT_HEX_PAD_1,		/* 7bit encoding, 1 bit of padding */
+	STR_ENCODING_7BIT_HEX_PAD_2,		/* 7bit encoding, 2 bits of padding */
+	STR_ENCODING_7BIT_HEX_PAD_3,		/* 7bit encoding, 3 bits padding */
+	STR_ENCODING_7BIT_HEX_PAD_4,		/* 7bit encoding, 4 bits padding */
+	STR_ENCODING_7BIT_HEX_PAD_5,		/* 7bit encoding, 5 bits padding */
+	STR_ENCODING_7BIT_HEX_PAD_6,		/* 7bit encoding, 6 bits padding */
 //	STR_ENCODING_8BIT,			/* 8bit */
 //	STR_ENCODING_UCS2,			/* UCS2 */
 	STR_ENCODING_UNKNOWN,			/* still unknown */

--- a/test/parse.c
+++ b/test/parse.c
@@ -9,6 +9,27 @@
 int ok = 0;
 int faults = 0;
 
+int test_strcmp(const char *pa, const char *pb)
+{
+	int retval;
+
+	if (pa == NULL)
+		pa = "";
+	if (pb == NULL)
+		pb = "";
+	retval = strcmp(pa,pb);
+
+	if (retval != 0) {
+		int x = 0;
+		while (pa[x] == pb[x] && pa[x] != 0) {
+			x++;
+		}
+		printf("String '%s' and '%s' differs at "
+		    "offset %d '%c' != '%c'\n", pa, pb, x, pa[x], pb[x]);
+	}
+	return (retval);
+}
+
 #/* */
 void test_parse_cnum()
 {
@@ -34,7 +55,7 @@ void test_parse_cnum()
 		input = strdup(cases[idx].input);
 		fprintf(stderr, "%s(\"%s\")...", "at_parse_cnum", input);
 		res = at_parse_cnum(input);
-		if(strcmp(res, cases[idx].result) == 0) {
+		if(test_strcmp(res, cases[idx].result) == 0) {
 			msg = "OK";
 			ok++;
 		} else {
@@ -67,7 +88,7 @@ void test_parse_cops()
 		input = strdup(cases[idx].input);
 		fprintf(stderr, "%s(\"%s\")...", "at_parse_cops", input);
 		res = at_parse_cops(input);
-		if(strcmp(res, cases[idx].result) == 0) {
+		if(test_strcmp(res, cases[idx].result) == 0) {
 			msg = "OK";
 			ok++;
 		} else {
@@ -112,9 +133,9 @@ void test_parse_creg()
 			&&
 		   result.gsm_reg_status == cases[idx].result.gsm_reg_status
 			&&
-		   strcmp(result.lac, cases[idx].result.lac) == 0
+		   test_strcmp(result.lac, cases[idx].result.lac) == 0
 			&&
-		   strcmp(result.ci, cases[idx].result.ci) == 0
+		   test_strcmp(result.ci, cases[idx].result.ci) == 0
 			) {
 			msg = "OK";
 			ok++;
@@ -203,7 +224,7 @@ void test_parse_cmgr()
 				"+11111111112",
 				STR_ENCODING_7BIT,
 				"B1582C168BC562B1984C2693C96432994C369BCD66B3D96C369BD168341A8D46A3D168B55AAD56ABD56AB59ACD66B3D96C369BCD76BBDD6EB7DBED76BBE170381C0E87C3E170B95C2E97CBE572B91C0C0683C16030180C",
-				STR_ENCODING_7BIT_HEX
+				STR_ENCODING_7BIT_HEX_PAD_0
 			} 
 		},
 		{ "+CMGR: 0,,159\r\n07919740430900F3440B912222222220F20008012180004390218C0500030003010031003100310031003100310031003100310031003200320032003200320032003200320032003200330033003300330033003300330033003300330034003400340034003400340034003400340034003500350035003500350035003500350035003500360036003600360036003600360036003600360037003700370037003700370037",
@@ -216,13 +237,34 @@ void test_parse_cmgr()
 				STR_ENCODING_UCS2_HEX
 			} 
 		},
-
+		{ "+CMGR: 0,,158\r\n07916407970970F6400A912222222222000041903021825180A0050003000301A9E5391D14060941439015240409414290102404094142901024040941429010240409414290106405594142901564055941429012A40429AD4AABD22A7481AC56101264455A915624C80AB282AC20A1D06A0559415610D20A4282AC2024C80AB282AC202BC80AB282AC2E9012B4042D414A90D2055282942E90D20502819420254809528294",
+			{
+				NULL,
+				"A9E5391D14060941439015240409414290102404094142901024040941429010240409414290106405594142901564055941429012A40429AD4AABD22A7481AC56101264455A915624C80AB282AC20A1D06A0559415610D20A4282AC2024C80AB282AC202BC80AB282AC2E9012B4042D414A90D2055282942E90D20502819420254809528294",
+				"+2222222222",
+				STR_ENCODING_7BIT,
+				"A9E5391D14060941439015240409414290102404094142901024040941429010240409414290106405594142901564055941429012A40429AD4AABD22A7481AC56101264455A915624C80AB282AC20A1D06A0559415610D20A4282AC2024C80AB282AC202BC80AB282AC2E9012B4042D414A90D2055282942E90D20502819420254809528294",
+				STR_ENCODING_7BIT_HEX_PAD_1,
+			}
+		},
+		{ "+CMGR: 0,,55\r\n07912933035011804409D055F3DB5D060000411120712071022A080701030003990202A09976D7E9E5390B640FB3D364103DCD668364B3562CD692C1623417",
+			{
+				NULL,
+				"A09976D7E9E5390B640FB3D364103DCD668364B3562CD692C1623417",
+				"553",
+				STR_ENCODING_7BIT,
+				"A09976D7E9E5390B640FB3D364103DCD668364B3562CD692C1623417",
+				STR_ENCODING_7BIT_HEX_PAD_5,
+			}
+		},
 	};
 
 	unsigned idx = 0;
 	char * input;
 	struct result result;
 	char oa[200];
+	char buffer_res[256];
+	char buffer_dec[256];
 	const char * msg;
 
 	result.oa = oa;
@@ -230,15 +272,15 @@ void test_parse_cmgr()
 		result.str = input = strdup(cases[idx].input);
 		fprintf(stderr, "%s(\"%s\")...", "at_parse_cmgr", input);
 		result.res = at_parse_cmgr(&result.str, strlen(result.str), result.oa, sizeof(oa), &result.oa_enc, &result.msg, &result.msg_enc);
-		if( ((result.res == NULL && result.res == cases[idx].result.res) || strcmp(result.res, cases[idx].result.res) == 0)
+		if( ((result.res == NULL && result.res == cases[idx].result.res) || test_strcmp(result.res, cases[idx].result.res) == 0)
 			&&
-		   strcmp(result.str, cases[idx].result.str) == 0
+		   test_strcmp(result.str, cases[idx].result.str) == 0
 			&&
-		   strcmp(result.oa, cases[idx].result.oa) == 0
+		   test_strcmp(result.oa, cases[idx].result.oa) == 0
 			&&
 		   result.oa_enc == cases[idx].result.oa_enc
 			&&
-		   strcmp(result.msg, cases[idx].result.msg) == 0
+		   test_strcmp(result.msg, cases[idx].result.msg) == 0
 			&&
 		   result.msg_enc == cases[idx].result.msg_enc
 			) {
@@ -248,7 +290,11 @@ void test_parse_cmgr()
 			msg = "FAIL";
 			faults++;
 		}
-		fprintf(stderr, " = '%s' ('%s','%s',%d,'%s',%d)\t%s\n", result.res, result.str, result.oa, result.oa_enc, result.msg, result.msg_enc, msg);
+		memset(buffer_res, 0, sizeof(buffer_res));
+		memset(buffer_dec, 0, sizeof(buffer_dec));
+		str_recode(RECODE_DECODE, result.msg_enc, result.msg, strlen(result.msg), buffer_res, sizeof(buffer_res));
+		str_recode(RECODE_DECODE, cases[idx].result.msg_enc, cases[idx].result.msg, strlen(cases[idx].result.msg), buffer_dec, sizeof(buffer_dec));
+		fprintf(stderr, " = '%s' ('%s','%s',%d,'%s',%d,'%s','%s')\t%s\n", result.res, result.str, result.oa, result.oa_enc, result.msg, result.msg_enc, buffer_res, buffer_dec, msg);
 		free(input);
 	}
 	fprintf(stderr, "\n");
@@ -286,7 +332,7 @@ void test_parse_cusd()
 			&&
 		   result.dcs == cases[idx].result.dcs
 			&&
-		   strcmp(result.cusd, cases[idx].result.cusd) == 0
+		   test_strcmp(result.cusd, cases[idx].result.cusd) == 0
 			) {
 			msg = "OK";
 			ok++;
@@ -369,7 +415,7 @@ void test_parse_clcc()
 			&&
 		   result.mpty == cases[idx].result.mpty
 			&&
-		   strcmp(result.number, cases[idx].result.number) == 0
+		   test_strcmp(result.number, cases[idx].result.number) == 0
 			&&
 		   result.toa == cases[idx].result.toa
 			) {


### PR DESCRIPTION
From: HPS hsela...@gmail.com
From: Shabbira shabbira...@gmail.com

Subject: Parses correctly multi-part SMS messages
Comitter: Rodrigo Freire rfreire@rf.usersys.redhat.com
Signed-off-by: Rodrigo Freire rfreire@rf.usersys.redhat.com

This patch was retrieved from
https://code.google.com/p/asterisk-chan-dongle/issues/detail?id=183
Now parses correctly multi-part SMS Messages. Verified on a Huawei E303S.
